### PR TITLE
Update 6.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.1" %}
+{% set version = "6.3.2" %}
 
 package:
   name: setuptools_scm
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-{{ version }}.tar.gz
-  sha256: d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92
+  sha256: a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2
 
 build:
   number: 0
@@ -19,19 +19,23 @@ outputs:
       noarch: python
     requirements:
       host:
-        - python >3.6
+        - python
         - pip
+        - setuptools
+        - wheel
       run:
-        - python >3.6 
-        - setuptools >45
-        - toml
+        - python >=3.6
+        - packaging >=20.0
+        - setuptools >=45
+        - tomli >=1.0.0
     test:
       imports:
         - setuptools_scm
-      commands:
-        - pip check
       requires:
         - pip
+        - python <3.10
+      commands:
+        - pip check
 
   - name: setuptools_scm
     build:
@@ -46,8 +50,11 @@ outputs:
 about:
   home: https://github.com/pypa/setuptools_scm/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: The blessed package to manage your versions by scm tags
+  dev_url: https://github.com/pypa/setuptools_scm/
+  doc_url: https://github.com/pypa/setuptools_scm/blob/main/README.rst
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Version change: bump version number from 6.0.1 to 6.3.2
Bug Tracker: new open issues https://github.com/pypa/setuptools_scm/issues
Upstream license:  License file:  https://github.com/pypa/setuptools_scm/blob/master/LICENSE
Upstream Changelog: https://github.com/pypa/setuptools_scm//blob/main/CHANGELOG.rst
Upstream setup.cfg:  https://github.com/pypa/setuptools_scm/blob/v6.3.2/setup.cfg
Upstream setup.py:  https://github.com/pypa/setuptools_scm/blob/v6.3.2/setup.py
Upstream pyproject.toml:  https://github.com/pypa/setuptools_scm/blob/v6.3.2/pyproject.toml

Actions:
1. Update dependencies
2. Add license_family, dev, doc urls

Result:
- all-succeeded