### PR TITLE
setuptools_scm 7.0.4

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,1 @@
+%PYTHON% -m pip install . --no-deps -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,12 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
 
 outputs:
   - name: setuptools-scm
-    script: {{ PYTHON }} -m pip install . --no-deps -vv
-    build:
-      skip: True  # [py<37]
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
     requirements:
       host:
         - python


### PR DESCRIPTION
Changelog: https://github.com/pypa/setuptools_scm/blob/v7.0.4/CHANGELOG.rst
License: https://github.com/pypa/setuptools_scm/blob/v7.0.4/LICENSE
Requierements:
- https://github.com/pypa/setuptools_scm/blob/v7.0.4/pyproject.toml
- https://github.com/pypa/setuptools_scm/blob/v7.0.4/setup.py
- https://github.com/pypa/setuptools_scm/blob/v7.0.4/setup.cfg

Actions:
1. Remove `noarch python`
2. Add `build_base.bat`
3. Skip` py<37`
4. Update host and run dependencies: add `typing-extensions` and `importlib-metadata  # [py<38]`
5. Remove `python <3.10` from `test/requires`