### PR TITLE
setuptools_scm 8.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "setuptools_scm" %}
 {% set name_var = name|replace("_", "-") %}
-{% set version = "8.0.4" %}
+{% set version = "8.1.0" %}
 
 package:
   name: setuptools_scm-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name_var }}/{{ name_var }}-{{ version }}.tar.gz
-  sha256: b5f43ff6800669595193fd09891564ee9d1d7dcb196cab4b2506d53a2e1c95c7
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name_var }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7
 
 build:
   number: 0
@@ -17,7 +17,7 @@ build:
 outputs:
   - name: setuptools-scm
     script: build_base.bat  # [win]
-    script: build_base.sh  # [not win]
+    script: build_base.sh   # [not win]
     requirements:
       host:
         - python
@@ -29,8 +29,8 @@ outputs:
         - python
         - packaging >=20.0
         - setuptools
-        - tomli >=1.0.0  # [py<311]
-        - typing-extensions
+        - tomli >=1.0.0      # [py<311]
+        - typing-extensions  # [py<310]
     test:
       imports:
         - setuptools_scm


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5275](https://anaconda.atlassian.net/browse/PKG-5275) 
- [Upstream repository](https://github.com/pypa/setuptools_scm/blob/v8.1.0)
- Releases: https://github.com/pypa/setuptools_scm/releases
- Requirements: https://github.com/pypa/setuptools_scm/blob/v8.1.0/pyproject.toml

### Explanation of changes:

- Fix `source/url`
- Use `typing-extensions` for `py<310` only

### Notes:

- Updating because broken CI on some settings following git update, see https://github.com/conda/conda/actions/runs/9881920885/job/27293763034?pr=14030

[PKG-5275]: https://anaconda.atlassian.net/browse/PKG-5275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ