### PR TITLE
Fixes compatibility with CRM and the recipe-bumper

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set name = "setuptools_scm" %}
-{% set name_var = name|replace("_", "-") %}
 {% set version = "8.1.0" %}
 
 package:
@@ -7,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name_var }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name|replace("_", "-") }}/{{ name }}-{{ version }}.tar.gz
   sha256: 42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
 
 outputs:


### PR DESCRIPTION
- `name_var` referencing another variable is preventing this file from being automatically updated by the recipe bumper bot
- It is much easier to get this recipe file in line with what most other recipe files do then it is to add support for recursive evaluation of JINJA variables. We can still explore that support in the future.